### PR TITLE
Update Packages (PHP Version and Spatie API)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,4 +1,3 @@
-
 name: tests
 
 on: [push, pull_request]
@@ -11,7 +10,7 @@ jobs:
             fail-fast: true
             matrix:
                 os: [ubuntu-latest, windows-latest]
-                php: [7.4, 7.3, 7.2]
+                php: [8.0, 8.1]
                 dependency-version: [prefer-stable]
 
         name: P${{ matrix.php }} - ${{ matrix.dependency-version }} - ${{ matrix.os }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,7 +4,6 @@ on: [push, pull_request]
 
 jobs:
     test:
-
         runs-on: ${{ matrix.os }}
         strategy:
             fail-fast: true
@@ -17,7 +16,10 @@ jobs:
 
         steps:
             -   name: Checkout code
-                uses: actions/checkout@v1
+                uses: actions/checkout@v2
+                with:
+                    fetch-depth: 1
+                    ref: ${{ github.ref }}
 
             -   name: Cache dependencies
                 uses: actions/cache@v1
@@ -26,7 +28,7 @@ jobs:
                     key: dependencies-php-${{ matrix.php }}-composer-${{ hashFiles('composer.json') }}
 
             -   name: Setup PHP
-                uses: shivammathur/setup-php@v1
+                uses: shivammathur/setup-php@v2
                 with:
                     php-version: ${{ matrix.php }}
                     extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, imagick

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ composer.lock
 docs
 vendor
 coverage
+.phpunit.result.cache

--- a/composer.json
+++ b/composer.json
@@ -21,11 +21,11 @@
         }
     ],
     "require": {
-        "php": "^7.2",
-        "spatie/packagist-api": "^1.2"
+        "php": "^8.0",
+        "spatie/packagist-api": "^2.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^7.0"
+        "phpunit/phpunit": "^9.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/PackagistLatestVersion.php
+++ b/src/PackagistLatestVersion.php
@@ -3,7 +3,6 @@
 namespace ahinkle\PackagistLatestVersion;
 
 use Exception;
-use GuzzleHttp\Client;
 use Spatie\Packagist\PackagistClient;
 
 class PackagistLatestVersion
@@ -41,7 +40,7 @@ class PackagistLatestVersion
 
     public function __construct()
     {
-        $this->packagist = new PackagistClient(new Client(), new \Spatie\Packagist\PackagistUrlGenerator());
+        $this->packagist = new PackagistClient(new \GuzzleHttp\Client(), new \Spatie\Packagist\PackagistUrlGenerator());
     }
 
     /**

--- a/src/PackagistLatestVersion.php
+++ b/src/PackagistLatestVersion.php
@@ -3,7 +3,7 @@
 namespace ahinkle\PackagistLatestVersion;
 
 use Exception;
-use \GuzzleHttp\Client;
+use GuzzleHttp\Client;
 use Spatie\Packagist\PackagistClient;
 
 class PackagistLatestVersion
@@ -47,7 +47,7 @@ class PackagistLatestVersion
     ];
 
     /**
-     * @param Client $client
+     * @param  Client  $client
      */
     public function __construct(Client $client)
     {
@@ -59,8 +59,9 @@ class PackagistLatestVersion
     /**
      * The latest release of the specified package.
      *
-     * @param string $package
+     * @param  string  $package
      * @return array|null
+     *
      * @throws Exception
      */
     public function getLatestRelease(string $package): ?array

--- a/src/PackagistLatestVersion.php
+++ b/src/PackagistLatestVersion.php
@@ -3,37 +3,38 @@
 namespace ahinkle\PackagistLatestVersion;
 
 use Exception;
-use GuzzleHttp\Client;
+use \GuzzleHttp\Client;
+use Spatie\Packagist\PackagistClient;
 
 class PackagistLatestVersion
 {
     /**
      * The Guzzle Client.
      *
-     * @var \GuzzleHttp\Client
+     * @var Client
      */
-    protected $client;
+    protected Client $client;
 
     /**
      * The Packagist API.
      *
-     * @var \Spatie\Packagist\Packagist
+     * @var PackagistClient
      */
-    protected $packagist;
+    protected PackagistClient $packagist;
 
     /**
      * The latest version of the package.
      *
-     * @var string|null
+     * @var array|null
      */
-    protected $latestVersion = null;
+    protected ?array $latestVersion = null;
 
     /**
      * Release tags that are considered `developmental` releases.
      *
      * @var array
      */
-    protected $developmentalTags = [
+    protected array $developmentalTags = [
         'alpha',
         'beta',
         'dev',
@@ -46,36 +47,35 @@ class PackagistLatestVersion
     ];
 
     /**
-     * @param \GuzzleHttp\Client $client
-     * @param string             $baseUrl
+     * @param Client $client
      */
-    public function __construct(Client $client, $baseUrl = 'https://packagist.org')
+    public function __construct(Client $client)
     {
         $this->client = $client;
 
-        $this->packagist = new \Spatie\Packagist\Packagist($client, $baseUrl);
+        $this->packagist = new PackagistClient($client, new \Spatie\Packagist\PackagistUrlGenerator());
     }
 
     /**
      * The latest release of the specified package.
      *
-     * @param string $vendor
-     *
-     * @return string|null
+     * @param string $package
+     * @return array|null
+     * @throws Exception
      */
-    public function getLatestRelease($package)
+    public function getLatestRelease(string $package): ?array
     {
         if ($package === '') {
             throw new Exception('You must pass a package value');
         }
 
-        $package = $this->packagist->getPackageMetaData($package);
+        $metadata = $this->packagist->getPackageMetaData($package);
 
-        if (! isset($package['package']['versions'])) {
-            return;
+        if (! isset($metadata['packages'][$package])) {
+            return null;
         }
 
-        return $this->resolveLatestRelease($package['package']['versions']);
+        return $this->resolveLatestRelease($metadata['packages'][$package]);
     }
 
     /**
@@ -84,10 +84,10 @@ class PackagistLatestVersion
      * @param  array  $releases
      * @return array|null
      */
-    public function resolveLatestRelease($releases)
+    public function resolveLatestRelease(array $releases): ?array
     {
         if (empty($releases)) {
-            return;
+            return null;
         }
 
         foreach ($releases as $release) {
@@ -108,12 +108,12 @@ class PackagistLatestVersion
     }
 
     /**
-     * If the the release tag is a developmental release.
+     * If the release tag is a developmental release.
      *
      * @param  string  $release
      * @return bool
      */
-    public function isDevelopmentalRelease($release)
+    public function isDevelopmentalRelease(string $release): bool
     {
         foreach ($this->developmentalTags as $developmentalTag) {
             if (stripos($release, $developmentalTag) !== false) {

--- a/src/PackagistLatestVersion.php
+++ b/src/PackagistLatestVersion.php
@@ -9,13 +9,6 @@ use Spatie\Packagist\PackagistClient;
 class PackagistLatestVersion
 {
     /**
-     * The Guzzle Client.
-     *
-     * @var Client
-     */
-    protected Client $client;
-
-    /**
      * The Packagist API.
      *
      * @var PackagistClient
@@ -46,14 +39,9 @@ class PackagistLatestVersion
         'wip',
     ];
 
-    /**
-     * @param  Client  $client
-     */
-    public function __construct(Client $client)
+    public function __construct()
     {
-        $this->client = $client;
-
-        $this->packagist = new PackagistClient($client, new \Spatie\Packagist\PackagistUrlGenerator());
+        $this->packagist = new PackagistClient(new Client(), new \Spatie\Packagist\PackagistUrlGenerator());
     }
 
     /**

--- a/tests/PackagistLatestVersionTest.php
+++ b/tests/PackagistLatestVersionTest.php
@@ -8,16 +8,18 @@ use PHPUnit\Framework\TestCase;
 
 class PackagistLatestVersionTest extends TestCase
 {
-    /** @var ahinkle\PackagistLatestVersion\PackagistLatestVersion */
-    protected $packagist;
+    /**
+     * @var PackagistLatestVersion
+     */
+    protected PackagistLatestVersion $packagist;
 
-    public function setUp()
+    public function setUp(): void
     {
+        parent::setUp();
+
         $client = new Client();
 
         $this->packagist = new PackagistLatestVersion($client);
-
-        parent::setUp();
     }
 
     public function test_it_can_instantiate_package_latest_version()

--- a/tests/PackagistLatestVersionTest.php
+++ b/tests/PackagistLatestVersionTest.php
@@ -17,9 +17,7 @@ class PackagistLatestVersionTest extends TestCase
     {
         parent::setUp();
 
-        $client = new Client();
-
-        $this->packagist = new PackagistLatestVersion($client);
+        $this->packagist = new PackagistLatestVersion();
     }
 
     public function test_it_can_instantiate_package_latest_version()

--- a/tests/PackagistLatestVersionTest.php
+++ b/tests/PackagistLatestVersionTest.php
@@ -3,7 +3,6 @@
 namespace ahinkle\PackagistLatestVersion\Tests;
 
 use ahinkle\PackagistLatestVersion\PackagistLatestVersion;
-use GuzzleHttp\Client;
 use PHPUnit\Framework\TestCase;
 
 class PackagistLatestVersionTest extends TestCase


### PR DESCRIPTION
- Bumps minimum PHP version to 8
- Updates Spatie API version to 2
- Fixes logic/test for new version changes
- Updates GH Actions to use PHP 8.x for testing