### PR TITLE
Allow to instantiate with a custom Guzzle client

### DIFF
--- a/src/PackagistLatestVersion.php
+++ b/src/PackagistLatestVersion.php
@@ -3,7 +3,9 @@
 namespace ahinkle\PackagistLatestVersion;
 
 use Exception;
+use GuzzleHttp\Client;
 use Spatie\Packagist\PackagistClient;
+use Spatie\Packagist\PackagistUrlGenerator;
 
 class PackagistLatestVersion
 {
@@ -38,9 +40,9 @@ class PackagistLatestVersion
         'wip',
     ];
 
-    public function __construct()
+    public function __construct(Client $client = null)
     {
-        $this->packagist = new PackagistClient(new \GuzzleHttp\Client(), new \Spatie\Packagist\PackagistUrlGenerator());
+        $this->packagist = new PackagistClient($client ?? new Client(), new PackagistUrlGenerator());
     }
 
     /**


### PR DESCRIPTION
Hi!

It looks like this used to be supported (according to the docs) but was removed in https://github.com/ahinkle/packagist-latest-version/pull/3.

Is it maybe something you'd reconsider supporting? My use-case is wanting to provide a user agent as is kindly requested in the Packagist API docs: https://packagist.org/apidoc

Thanks!
